### PR TITLE
fix: resolve runtime ID for selected container instead of hardcoded containers[0]

### DIFF
--- a/internal/ecs/ecs.go
+++ b/internal/ecs/ecs.go
@@ -118,11 +118,12 @@ func SelectECSTask(cluster, service, profile, region string) (string, error) {
 	return utils.PromptSelection(tasks, "ECS Task")
 }
 
-// Fetches the details for an ECS task
-func GetTaskDetails(cluster, taskID, profile, region string) (string, error) {
+// Fetches the runtime ID for a specific container in an ECS task
+func GetTaskDetails(cluster, taskID, containerName, profile, region string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "aws", "ecs", "describe-tasks", "--cluster", cluster, "--tasks", taskID, "--query", "tasks[0].containers[0].runtimeId", "--output", "text", "--profile", profile, "--region", region)
+	query := fmt.Sprintf("tasks[0].containers[?name==`%s`].runtimeId | [0]", containerName)
+	cmd := exec.CommandContext(ctx, "aws", "ecs", "describe-tasks", "--cluster", cluster, "--tasks", taskID, "--query", query, "--output", "text", "--profile", profile, "--region", region)
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -130,7 +131,11 @@ func GetTaskDetails(cluster, taskID, profile, region string) (string, error) {
 		}
 		return "", fmt.Errorf("failed to fetch ECS task details: %v", err)
 	}
-	return strings.TrimSpace(string(output)), nil
+	runtimeID := strings.TrimSpace(string(output))
+	if runtimeID == "" || runtimeID == "None" {
+		return "", fmt.Errorf("no runtime ID found for container %s in task %s", containerName, taskID)
+	}
+	return runtimeID, nil
 }
 
 // Fetches the container names for a given task

--- a/internal/functions/portforward.go
+++ b/internal/functions/portforward.go
@@ -57,11 +57,11 @@ func ExecutePortForwarding() error {
 		if err != nil {
 			return err
 		}
-		runtimeID, err := ecs.GetTaskDetails(cluster, taskID, selectedProfile, selectedRegion)
+		containerName, err := ecs.SelectECSContainer(cluster, taskID, selectedProfile, selectedRegion)
 		if err != nil {
 			return err
 		}
-		containerName, err := ecs.SelectECSContainer(cluster, taskID, selectedProfile, selectedRegion)
+		runtimeID, err := ecs.GetTaskDetails(cluster, taskID, containerName, selectedProfile, selectedRegion)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#2 

**Summary**
Fixes TargetNotConnected errors during ECS port forwarding when the selected container is not the first container in the task.

**Problem**
GetTaskDetails hardcoded tasks[0].containers[0].runtimeId, always returning the first container's runtime ID. Additionally, the runtime ID was fetched before the user selected a container, so the selection was never used in the SSM target.

This meant port forwarding only worked by coincidence when the desired container happened to be at index 0.

**Changes**
Reordered the flow in portforward.go: container selection now happens before fetching the runtime ID
Updated GetTaskDetails in ecs.go to accept a containerName parameter and filter with containers[?name==\<name>`].runtimeIdinstead ofcontainers[0].runtimeId`

**Tested**
Verified the JMESPath query returns the correct runtime ID for sbom-prod-dt-frontend-container (previously failing case)
Built locally with go build and ran portforward end-to-end — SSM session connected successfully